### PR TITLE
Simplify npm start script

### DIFF
--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/micromata/webengineering-2017",
   "license": "Apache-2.0",
   "scripts": {
-    "start": "node ./node_modules/.bin/webpack -w"
+    "start": "webpack -w"
   },
   "author": "Michael Lesniak <mlesniak@micromata.de>",
   "devDependencies": {


### PR DESCRIPTION
Hej Michael,

you could simplify the declaration of the start script.
When running npm scripts you can address locally installed binaries just as they were installed globally. 

See [npm docs](https://docs.npmjs.com/misc/scripts#environment) for details 😘 

Yours, Michael