### PR TITLE
Replace babel presets

### DIFF
--- a/src/main/frontend/.babelrc
+++ b/src/main/frontend/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [
     "react",
-    "es2015",
-    "stage-1"
+    "env"
   ]
 }

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -12,14 +12,13 @@
   "devDependencies": {
     "babel-core": "6.24.1",
     "babel-loader": "7.0.0-beta.1",
-    "babel-preset-es2015": "6.24.1",
+    "babel-preset-env": "^1.5.2",
     "babel-preset-react": "6.24.1",
     "webpack": "2.4.1",
     "copy-webpack-plugin": "4.0.1"
   },
   "dependencies": {
     "axios": "^0.16.2",
-    "babel-preset-stage-1": "6.24.1",
     "react": "15.5.4",
     "react-dom": "^15.5.4"
   }


### PR DESCRIPTION
Hej Michael,

I advise you to:
- Use babel preset env by default
  - Using it with no additional config (like we do now in `.babelrc`) makes it behave like the deprecated [Latest preset](https://babeljs.io/docs/plugins/preset-latest/): It includes all ECMAScript presets from ES6 until now. Which are as of today: 
    - es2017
    - es2016
    - es2015
  - You can optionally enhance the configuration to only transpile the code your target browsers aren’t able to execute natively. See [Babel docs](https://babeljs.io/docs/plugins/preset-env/) for detailed information.
- Avoid using stage 1 as well as stage 2 presets in case you don’t really need ’em. In Short: The specs are in subject to chance (or don’t even land in an ECMAScript release). Stage 3 and stage 4 on the other hand should be somewhere between pretty stable and rock solid. See these short explanations of each and every stage of the [TC39 process](http://exploringjs.com/es2016-es2017/ch_tc39-process.html#_solution-the-tc39-process).

Cheers, Michael