### PR TITLE
Fix Regression Introduced In #20

### DIFF
--- a/src/main/frontend/webpack.config.js
+++ b/src/main/frontend/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
             exclude: /node_modules/,
             loader: 'babel-loader',
             query: {
-                presets: ['react', 'es2015', 'stage-1']
+                presets: ['react', 'env']
             }
         }]
     },


### PR DESCRIPTION
`npm start`/webpack bundling fails because the presets `es2015`/`stage-1` were changed to `env` in #20.

Error log:
```
Version: webpack 2.4.1
Time: 515ms
                 Asset       Size  Chunks             Chunk Names
             bundle.js    4.36 kB       0  [emitted]  main
         bundle.js.map    2.62 kB       0  [emitted]  main
       assets/main.css  688 bytes          [emitted]  
        assets/dog.png     167 kB          [emitted]  
locales/de/common.json   51 bytes          [emitted]  
locales/en/common.json   45 bytes          [emitted]  
            index.html  783 bytes          [emitted]  
   [0] ./src/index.js 1.57 kB {0} [built] [failed] [1 error]
   [1] multi ./src/index.js 28 bytes {0} [built]

ERROR in ./src/index.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory "/tmp/webengineering-2017/src/main/frontend/src"
    at /tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/options/option-manager.js:293:19
    at Array.map (native)
    at OptionManager.resolvePresets (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-loader/lib/index.js:48:20)
    at Object.module.exports (/tmp/webengineering-2017/src/main/frontend/node_modules/babel-loader/lib/index.js:163:20)
 @ multi ./src/index.js
```